### PR TITLE
Allow sync level '0' (different than None).

### DIFF
--- a/yubico/yubico.py
+++ b/yubico/yubico.py
@@ -212,7 +212,7 @@ class Yubico():
         if timestamp:
             data.append(('timestamp', '1'))
 
-        if sl:
+        if sl is not None:
             if sl not in range(0, 101) and sl not in ['fast', 'secure']:
                 raise Exception('sl parameter value must be between 0 and '
                                  '100 or string "fast" or "secure"')


### PR DESCRIPTION
sl=0 was actually broken in the server side code too, but we're rolling out a fix for that while upgrading servers. Two servers are already upgraded and will accept sl=0 - the others will respond BAD_SIGNATURE.

/Fredrik
