### PR TITLE
Avoid busy-looping when waiting for responses.

### DIFF
--- a/yubico/yubico.py
+++ b/yubico/yubico.py
@@ -108,6 +108,7 @@ class Yubico():
                         else:
                             return True
                     threads.remove(thread)
+            time.sleep(0.1)
 
         # Timeout or no valid response received
         raise Exception('NO_VALID_ANSWERS')


### PR DESCRIPTION
We saw a noticeable CPU increase on our monitoring server with a few python-yubico-client validations per minute. This patch got us back to normal.

/Fredrik
