### PR TITLE
Add in some logic to select a CA bundle

### DIFF
--- a/yubico/httplib_ssl.py
+++ b/yubico/httplib_ssl.py
@@ -31,12 +31,12 @@ common_ca_file_locations = [
 ]
 
 if os.getenv('SSL_CERT_FILE', False) and os.path.exists(os.environ['SSL_CERT_FILE']):
-	CA_CERTS = os.environ['SSL_CERT_FILE']
+    CA_CERTS = os.environ['SSL_CERT_FILE']
 else:
     for location in common_ca_file_locations:
-	if os.path.exists(location):
-	    CA_CERTS = location
-	    break
+        if os.path.exists(location):
+           CA_CERTS = location
+           break
 
 class VerifiedHTTPSConnection(httplib.HTTPSConnection):
     def connect(self):


### PR DESCRIPTION
This was mainly inspired by https://github.com/google/signet, but I didn't think having to hard code in the path to the CA file was worth it, so I added in a check for the SSL_CERT_FILE environment variable and used a default set of locations to try and find the system CA bundle.
