### PR TITLE
query string's values must be quoted/unquoted when splitting-sorting

### DIFF
--- a/yubico_client/py3.py
+++ b/yubico_client/py3.py
@@ -45,6 +45,7 @@ if sys.version_info >= (3, 2) and sys.version_info < (3, 3):
 
 if PY3:
     from urllib.parse import urlencode as urlencode
+    from urllib.parse import unquote as unquote
 
     u = str
 
@@ -57,6 +58,7 @@ if PY3:
             raise TypeError("Invalid argument %r for b()" % (s,))
 else:
     from urllib import urlencode as urlencode  # NOQA
+    from urllib import unquote as unquote  # NOQA
 
     u = unicode
     b = bytes = str

--- a/yubico_client/yubico.py
+++ b/yubico_client/yubico.py
@@ -28,7 +28,7 @@ from yubico_client.yubico_exceptions import (StatusCodeError,
                                              InvalidValidationResponse,
                                              SignatureVerificationError)
 from yubico_client.py3 import b
-from yubico_client.py3 import urlencode
+from yubico_client.py3 import urlencode, unquote
 
 logger = logging.getLogger('yubico.client')
 
@@ -251,6 +251,7 @@ class Yubico(object):
             # Signature located in the response does not match the one we
             # have generated
             if signature != generated_signature:
+                logger.warn("signature mismatch for parameters=%r", parameters)
                 raise SignatureVerificationError(generated_signature,
                                                  signature)
         param_dict = self.get_parameters_as_dictionary(parameters)
@@ -311,10 +312,9 @@ class Yubico(object):
         Returns a HMAC-SHA-1 signature for the given query string.
         http://goo.gl/R4O0E
         """
-        pairs = query_string.split('&')
-        pairs = [pair.split('=') for pair in pairs]
-        pairs_sorted = sorted(pairs)
-        pairs_string = '&' . join(['=' . join(pair) for pair in pairs_sorted])
+        # split for sorting
+        pairs = sorted(pair.split('=', 1) for pair in query_string.split('&'))
+        pairs_string = '&' . join('=' . join(pair) for pair in pairs)
 
         digest = hmac.new(self.key, b(pairs_string), hashlib.sha1).digest()
         signature = base64.b64encode(digest).decode('utf-8')
@@ -327,31 +327,19 @@ class Yubico(object):
         server response. 'h' aka signature argument is stripped from the
         returned query string.
         """
-        split = [pair.strip() for pair in response.split('\n')
-                 if pair.strip() != '']
-        query_string = '&' . join(split)
-        split_dict = self.get_parameters_as_dictionary(query_string)
-
-        if 'h' in split_dict:
-            signature = split_dict['h']
-            del split_dict['h']
-        else:
-            signature = None
-
-        query_string = ''
-        for index, (key, value) in enumerate(split_dict.items()):
-            query_string += '%s=%s' % (key, value)
-
-            if index != len(split_dict) - 1:
-                query_string += '&'
+        pairs = sorted(line.strip().split('=', 1)
+                       for line in response.splitlines()
+                       if '=' in line)
+        signature = ([unquote(v) for k, v in pairs if k == 'h'] or [None])[0]
+        # already quoted
+        query_string = '&' . join(k + '=' + v for k, v in pairs if k != 'h')
 
         return (signature, query_string)
 
     def get_parameters_as_dictionary(self, query_string):
         """ Returns query string parameters as a dictionary. """
-        dictionary = dict([parameter.split('=', 1) for parameter
-                           in query_string.split('&')])
-        return dictionary
+        pairs = (x.split('=', 1) for x in query_string.split('&'))
+        return dict((k, unquote(v)) for k, v in pairs)
 
     def _init_request_urls(self, api_urls):
         """


### PR DESCRIPTION
I have reimplemented yubikey-val in Go (https://github.com/tgulacsi/yubikey-val/tree/go), and found some incompatibilities:

Hash of the response of the yubikey-val program is constructed into a query string,
but the values (esp. the date) may not be in a proper query string, must be escaped.

Example:
yubikey-val:
```
2014-10-01T12:59:53.31724 t=2014-10-01T14:59:53+0200 lvl=dbug msg=sign message="nonce=K6VsdKoaSebwFnf1Je6TGbKMn&otp=cccccccccccbvkikfhv
ghffnhfbbccjbngibrtkcclbk&sl=60&status=OK&t=2014-10-01T14%3A59%3A53%2B02%3A00" key="W?;`�H�s9c!Ě$p��("
2014-10-01T12:59:53.31751 t=2014-10-01T14:59:53+0200 lvl=info msg=Response ip=127.0.0.1:49249 version=2.0 otp=cccccccccccbvkikfhvghffnh
fbbccjbngibrtkcclbk body="h=K2NVWpFPspFofWezNGcnITamx/s=\r\nt=2014-10-01T14:59:53+02:00\r\nnonce=K6VsdKoaSebwFnf1Je6TGbKMn\r\nsl=60\r\notp=cccccccccccbvkikfhvghffnhfbbccjbngibrtkcclbk\r\nstatus=OK\r\n\r\n"
```

yubiauth:
```
[DEBUG] 2014-10-01 14:59:53 urllib3.connectionpool: "GET /wsapi/2.0/verify?id=2&otp=cccccccccccbvkikfhvghffnhfbbccjbngibrtkcclbk&nonce=
K6VsdKoaSebwFnf1Je6TGbKMn&h=3UK5hkB9WATwy1MRWDW6n2CzgnM= HTTP/1.1" 200 164
[DEBUG] 2014-10-01 14:59:53 yubico.client: Received response from http://127.0.0.1:12345/wsapi/2.0/verify?id=2&otp=cccccccccccbvkikfhvg
hffnhfbbccjbngibrtkcclbk&nonce=K6VsdKoaSebwFnf1Je6TGbKMn&h=3UK5hkB9WATwy1MRWDW6n2CzgnM= (thread=Thread-2): h=K2NVWpFPspFofWezNGcnITamx/
s=
t=2014-10-01T14:59:53+02:00
nonce=K6VsdKoaSebwFnf1Je6TGbKMn
sl=60
otp=cccccccccccbvkikfhvghffnhfbbccjbngibrtkcclbk
status=OK


[WARNING] 2014-10-01 14:59:53 yubico.client: key='W?;`\xccH\x11\x10\xd7s9c!\xc4\x9a$p\x95\x80(' parameters=u'nonce=K6VsdKoaSebwFnf1Je6T
GbKMn&otp=cccccccccccbvkikfhvghffnhfbbccjbngibrtkcclbk&sl=60&status=OK&t=2014-10-01T14:59:53+02:00' generated=u'm43fdVeLbWzHVCYuWa6mzH8
OXZs=' got=u'K2NVWpFPspFofWezNGcnITamx/s='
```


After this change:
```
2014-10-01T13:54:31.23497 t=2014-10-01T15:54:31+0200 lvl=dbug msg=sign message="nonce=JewhaxeIx46pjh2XDNWiLz1Bl&otp=cccccccccccbjjjgtfdtlelfkhtnnbueiurilluvjnkc&sl=60&status=OK&t=2014-10-01T15%3A54%3A31%2B02%3A00" key="W?;`�H�s9c!Ě$p��("
2014-10-01T13:54:31.23497 t=2014-10-01T15:54:31+0200 lvl=info msg=Response ip=127.0.0.1:49267 version=2.0 otp=cccccccccccbjjjgtfdtlelfkhtnnbueiurilluvjnkc body="h=zy8A99+thYQUPRO5n2QB15R70Y8=\r\nt=2014-10-01T15:54:31+02:00\r\nsl=60\r\notp=cccccccccccbjjjgtfdtlelfkhtnnbueiurilluvjnkc\r\nnonce=JewhaxeIx46pjh2XDNWiLz1Bl\r\nstatus=OK\r\n\r\n"
```

```
[DEBUG] 2014-10-01 15:54:31 urllib3.connectionpool: "GET /wsapi/2.0/verify?id=2&otp=cccccccccccbjjjgtfdtlelfkhtnnbueiurilluvjnkc&nonce=JewhaxeIx46pjh2XDNWiLz1Bl&h=X7W8UI4phSkZ6HXfZ2Pa/nFYIaA= HTTP/1.1" 200 164
[DEBUG] 2014-10-01 15:54:31 yubico.client: Received response from http://127.0.0.1:12345/wsapi/2.0/verify?id=2&otp=cccccccccccbjjjgtfdtlelfkhtnnbueiurilluvjnkc&nonce=JewhaxeIx46pjh2XDNWiLz1Bl&h=X7W8UI4phSkZ6HXfZ2Pa/nFYIaA= (thread=Thread-1): h=zy8A99+thYQUPRO5n2QB15R70Y8=
t=2014-10-01T15:54:31+02:00
sl=60
otp=cccccccccccbjjjgtfdtlelfkhtnnbueiurilluvjnkc
nonce=JewhaxeIx46pjh2XDNWiLz1Bl
status=OK


[INFO] 2014-10-01 15:54:31 yubiauth.util.utils: validate_otp(u'cccccccccccbjjjgtfdtlelfkhtnnbueiurilluvjnkc'): True
[INFO] 2014-10-01 15:54:31 yubiauth.client.controller: Authentication successful. Username: None, password: <valid password>, OTP: cccccccccccbjjjgtfdtlelfkhtnnbueiurilluvjnkc
```