### PR TITLE
Retry server errors that might work on a retry

### DIFF
--- a/tests/mock_http_server.py
+++ b/tests/mock_http_server.py
@@ -68,6 +68,9 @@ class Handler(BaseHTTPRequestHandler):
         elif mock_action == 'timeout':
             time.sleep(1)
             return self._send_status(status='OK')
+        elif mock_action == 'one_gateway_error':
+            mock_action = 'no_signature_ok'
+            return self._end(status_code=502)
         else:
             self._end(status_code=500)
             return

--- a/tests/test_yubico.py
+++ b/tests/test_yubico.py
@@ -168,6 +168,12 @@ class TestYubicoVerifySingle(unittest.TestCase):
         else:
             self.fail('Exception was not thrown')
 
+    def test_verify_retries_500_responses(self):
+        self._set_mock_action('one_gateway_error')
+
+        status = self.client_no_verify_sig.verify('test')
+        self.assertTrue(status)
+
     def test_verify_multi_different_device_ids(self):
         otp_list = [
             'tlerefhcvijlngibueiiuhkeibbcbecehvjiklltnbbl',


### PR DESCRIPTION
Proxy and gateway timeouts can result in a NO_VALID_ANSWERS response.

When these are an HTTP status code that indicates something might work on retry, retry those requests.